### PR TITLE
feat: replace select elements with custom Select component

### DIFF
--- a/src/app/dashboard/training/new/configuration/page.tsx
+++ b/src/app/dashboard/training/new/configuration/page.tsx
@@ -24,6 +24,13 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import type { TrainingConfig } from "@/types/training";
 import { useAtom } from "jotai";
 import { useRouter } from "next/navigation";
@@ -238,19 +245,33 @@ export default function TrainingConfigPage() {
 	}) => (
 		<div className="space-y-1">
 			<Label htmlFor={String(field)}>{label}</Label>
-			<select
-				id={String(field)}
-				name={String(field)}
+			<Select
 				value={String(config?.hyperparameters[field] ?? "")}
-				onChange={handleHyperparameterChange}
-				className="w-full p-2 border rounded"
+				onValueChange={(value: string) =>
+					setConfig(prev =>
+						prev
+							? {
+									...prev,
+									hyperparameters: {
+										...prev.hyperparameters,
+										[String(field)]: value,
+									},
+								}
+							: null,
+					)
+				}
 			>
-				{options.map(option => (
-					<option key={option.value} value={option.value}>
-						{option.label}
-					</option>
-				))}
-			</select>
+				<SelectTrigger className="w-full">
+					<SelectValue placeholder="Select an option" />
+				</SelectTrigger>
+				<SelectContent>
+					{options.map(option => (
+						<SelectItem key={option.value} value={option.value}>
+							{option.label}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
 		</div>
 	);
 
@@ -281,19 +302,25 @@ export default function TrainingConfigPage() {
 	}) => (
 		<div className="space-y-1">
 			<Label htmlFor={String(field)}>{label}</Label>
-			<select
-				id={String(field)}
-				name={String(field)}
+			<Select
 				value={String(config?.[field] ?? "")}
-				onChange={handleCoreConfigChange}
-				className="w-full p-2 border rounded"
+				onValueChange={(value: string) =>
+					setConfig(prev =>
+						prev ? { ...prev, [field]: value } : null,
+					)
+				}
 			>
-				{options.map(option => (
-					<option key={option.value} value={option.value}>
-						{option.label}
-					</option>
-				))}
-			</select>
+				<SelectTrigger className="w-full">
+					<SelectValue placeholder="Select an option" />
+				</SelectTrigger>
+				<SelectContent>
+					{options.map(option => (
+						<SelectItem key={option.value} value={option.value}>
+							{option.label}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
 		</div>
 	);
 
@@ -308,19 +335,33 @@ export default function TrainingConfigPage() {
 	}) => (
 		<div className="space-y-1">
 			<Label htmlFor={String(field)}>{label}</Label>
-			<select
-				id={String(field)}
-				name={String(field)}
+			<Select
 				value={String(config?.export_config[field] ?? "")}
-				onChange={handleExportConfigChange}
-				className="w-full p-2 border rounded"
+				onValueChange={(value: string) =>
+					setConfig(prev =>
+						prev
+							? {
+									...prev,
+									export_config: {
+										...prev.export_config,
+										[String(field)]: value,
+									},
+								}
+							: null,
+					)
+				}
 			>
-				{options.map(option => (
-					<option key={option.value} value={option.value}>
-						{option.label}
-					</option>
-				))}
-			</select>
+				<SelectTrigger className="w-full">
+					<SelectValue placeholder="Select an option" />
+				</SelectTrigger>
+				<SelectContent>
+					{options.map(option => (
+						<SelectItem key={option.value} value={option.value}>
+							{option.label}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
 		</div>
 	);
 
@@ -351,19 +392,33 @@ export default function TrainingConfigPage() {
 	}) => (
 		<div className="space-y-1">
 			<Label htmlFor={String(field)}>{label}</Label>
-			<select
-				id={String(field)}
-				name={String(field)}
+			<Select
 				value={String(config?.eval_config?.[field] ?? "")}
-				onChange={handleEvalConfigChange}
-				className="w-full p-2 border rounded"
+				onValueChange={(value: string) =>
+					setConfig(prev =>
+						prev
+							? {
+									...prev,
+									eval_config: {
+										...(prev.eval_config || {}),
+										[String(field)]: value,
+									},
+								}
+							: null,
+					)
+				}
 			>
-				{options.map(option => (
-					<option key={option.value} value={option.value}>
-						{option.label}
-					</option>
-				))}
-			</select>
+				<SelectTrigger className="w-full">
+					<SelectValue placeholder="Select an option" />
+				</SelectTrigger>
+				<SelectContent>
+					{options.map(option => (
+						<SelectItem key={option.value} value={option.value}>
+							{option.label}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
 		</div>
 	);
 
@@ -760,25 +815,48 @@ export default function TrainingConfigPage() {
 								</div>
 								<div className="space-y-1">
 									<Label>Log Model to WandB</Label>
-									<select
-										name="log_model"
+									<Select
 										value={
 											config?.wandb_config?.log_model ??
 											"end"
 										}
-										onChange={handleWandbConfigChange}
-										className="w-full p-2 border rounded"
+										onValueChange={(
+											value:
+												| "false"
+												| "checkpoint"
+												| "end",
+										) =>
+											setConfig(prev => {
+												if (!prev) return null;
+												const wandbConfig =
+													prev.wandb_config || {
+														api_key: "",
+													};
+												return {
+													...prev,
+													wandb_config: {
+														...wandbConfig,
+														log_model: value,
+													},
+												};
+											})
+										}
 									>
-										<option value="false">
-											Don't Log Model
-										</option>
-										<option value="checkpoint">
-											Log Checkpoints
-										</option>
-										<option value="end">
-											Log Final Model
-										</option>
-									</select>
+										<SelectTrigger className="w-full">
+											<SelectValue placeholder="Select an option" />
+										</SelectTrigger>
+										<SelectContent>
+											<SelectItem value="false">
+												Don't Log Model
+											</SelectItem>
+											<SelectItem value="checkpoint">
+												Log Checkpoints
+											</SelectItem>
+											<SelectItem value="end">
+												Log Final Model
+											</SelectItem>
+										</SelectContent>
+									</Select>
 								</div>
 							</AccordionContent>
 						</AccordionItem>

--- a/src/components/batch-inference-form.tsx
+++ b/src/components/batch-inference-form.tsx
@@ -148,11 +148,9 @@ export default function BatchInferenceForm({ job }: BatchInferenceFormProps) {
 					<label htmlFor="split" className="font-semibold">
 						Split:
 					</label>
-					<select
-						id="split"
+					<Select
 						value={selectedSplit}
-						onChange={e => {
-							const splitName = e.target.value;
+						onValueChange={splitName => {
 							setSelectedSplit(splitName);
 							const split = splits.find(
 								s => s.split_name === splitName,
@@ -166,14 +164,21 @@ export default function BatchInferenceForm({ job }: BatchInferenceFormProps) {
 							setSelected([]);
 							setResults([]);
 						}}
-						className="border rounded p-1"
 					>
-						{splits.map(s => (
-							<option key={s.split_name} value={s.split_name}>
-								{s.split_name}
-							</option>
-						))}
-					</select>
+						<SelectTrigger className="w-[200px]">
+							<SelectValue placeholder="Select split" />
+						</SelectTrigger>
+						<SelectContent>
+							{splits.map(s => (
+								<SelectItem
+									key={s.split_name}
+									value={s.split_name}
+								>
+									{s.split_name}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
 				</div>
 			)}
 			{splits.length > 0 && samples.length === 0 && (

--- a/src/components/reward-configurator.tsx
+++ b/src/components/reward-configurator.tsx
@@ -14,6 +14,15 @@ import { toast } from "sonner";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectGroup,
+	SelectItem,
+	SelectLabel,
+	SelectTrigger,
+	SelectValue,
+} from "./ui/select";
 import { Textarea } from "./ui/textarea";
 
 const Field = ({
@@ -73,27 +82,30 @@ const GraderConfigCard = ({
 							/>
 						</Field>
 						<Field id={operationId} label="Operation">
-							<select
-								id={operationId}
+							<Select
 								value={grader.operation}
-								onChange={e =>
+								onValueChange={(
+									value: StringCheckRewardConfig["operation"],
+								) =>
 									handleUpdate(g => {
 										const scg =
 											g as StringCheckRewardConfig;
-										return {
-											...scg,
-											operation: e.target
-												.value as StringCheckRewardConfig["operation"],
-										};
+										return { ...scg, operation: value };
 									})
 								}
-								className="w-full p-2 border rounded"
 							>
-								<option value="eq">Equals</option>
-								<option value="ne">Not Equals</option>
-								<option value="like">Like</option>
-								<option value="ilike">iLike</option>
-							</select>
+								<SelectTrigger className="w-full">
+									<SelectValue placeholder="Select operation" />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="eq">Equals</SelectItem>
+									<SelectItem value="ne">
+										Not Equals
+									</SelectItem>
+									<SelectItem value="like">Like</SelectItem>
+									<SelectItem value="ilike">iLike</SelectItem>
+								</SelectContent>
+							</Select>
 						</Field>
 					</>
 				);
@@ -137,40 +149,44 @@ const GraderConfigCard = ({
 							id={evaluationMetricId}
 							label="Evaluation Metric"
 						>
-							<select
-								id={evaluationMetricId}
+							<Select
 								value={grader.evaluation_metric}
-								onChange={e =>
+								onValueChange={(
+									value: TextSimilarityRewardConfig["evaluation_metric"],
+								) =>
 									handleUpdate(g => {
 										const tsg =
 											g as TextSimilarityRewardConfig;
 										return {
 											...tsg,
-											evaluation_metric: e.target
-												.value as TextSimilarityRewardConfig["evaluation_metric"],
+											evaluation_metric: value,
 										};
 									})
 								}
-								className="w-full p-2 border rounded"
 							>
-								{[
-									"fuzzy_match",
-									"bleu",
-									"gleu",
-									"meteor",
-									"cosine",
-									"rouge_1",
-									"rouge_2",
-									"rouge_3",
-									"rouge_4",
-									"rouge_5",
-									"rouge_l",
-								].map(m => (
-									<option key={m} value={m}>
-										{m}
-									</option>
-								))}
-							</select>
+								<SelectTrigger className="w-full">
+									<SelectValue placeholder="Select metric" />
+								</SelectTrigger>
+								<SelectContent>
+									{[
+										"fuzzy_match",
+										"bleu",
+										"gleu",
+										"meteor",
+										"cosine",
+										"rouge_1",
+										"rouge_2",
+										"rouge_3",
+										"rouge_4",
+										"rouge_5",
+										"rouge_l",
+									].map(m => (
+										<SelectItem key={m} value={m}>
+											{m}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
 						</Field>
 						<Field id={embeddingModelId} label="Embedding Model">
 							<Input
@@ -387,32 +403,33 @@ const GraderConfigCard = ({
 				return (
 					<>
 						<Field id={functionNameId} label="Function Name">
-							<select
-								id={functionNameId}
+							<Select
 								value={builtInGrader.function_name}
-								onChange={e =>
+								onValueChange={(
+									value: BuiltInRewardConfig["function_name"],
+								) =>
 									handleUpdate(g => {
 										const big = g as BuiltInRewardConfig;
-										return {
-											...big,
-											function_name: e.target
-												.value as BuiltInRewardConfig["function_name"],
-										};
+										return { ...big, function_name: value };
 									})
 								}
-								className="w-full p-2 border rounded"
 							>
-								{[
-									"format_reward",
-									"count_xml",
-									"expression_accuracy",
-									"numerical_accuracy",
-								].map(f => (
-									<option key={f} value={f}>
-										{f}
-									</option>
-								))}
-							</select>
+								<SelectTrigger className="w-full">
+									<SelectValue placeholder="Select function" />
+								</SelectTrigger>
+								<SelectContent>
+									{[
+										"format_reward",
+										"count_xml",
+										"expression_accuracy",
+										"numerical_accuracy",
+									].map(f => (
+										<SelectItem key={f} value={f}>
+											{f}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
 						</Field>
 						<Field id={thinkTagId} label="Think Tag">
 							<Input
@@ -685,26 +702,40 @@ export function RewardConfigurator() {
 				))}
 			</div>
 			<div className="flex items-center gap-2 pt-4">
-				<select
+				<Select
 					value={selectedGraderType}
-					onChange={e =>
-						setSelectedGraderType(
-							e.target.value as AnyGraderConfig["type"] | "",
-						)
+					onValueChange={(value: AnyGraderConfig["type"] | "") =>
+						setSelectedGraderType(value)
 					}
-					className="w-full p-2 border rounded"
 				>
-					<option value="">Select Grader Type to Add</option>
-					<option value="built_in">Built-in Reward Functions</option>
-					<option value="string_check">String Check</option>
-					<option value="text_similarity">Text Similarity</option>
-					<option value="score_model">Score Model</option>
-					<option value="label_model">Label Model</option>
-					<option value="python">
-						Custom Python Reward Functions
-					</option>
-					<option value="ruler">Ruler</option>
-				</select>
+					<SelectTrigger className="w-full">
+						<SelectValue placeholder="Select Grader Type to Add" />
+					</SelectTrigger>
+					<SelectContent>
+						<SelectGroup>
+							<SelectLabel>Select Grader Type to Add</SelectLabel>
+							<SelectItem value="built_in">
+								Built-in Reward Functions
+							</SelectItem>
+							<SelectItem value="string_check">
+								String Check
+							</SelectItem>
+							<SelectItem value="text_similarity">
+								Text Similarity
+							</SelectItem>
+							<SelectItem value="score_model">
+								Score Model
+							</SelectItem>
+							<SelectItem value="label_model">
+								Label Model
+							</SelectItem>
+							<SelectItem value="python">
+								Custom Python Reward Functions
+							</SelectItem>
+							<SelectItem value="ruler">Ruler</SelectItem>
+						</SelectGroup>
+					</SelectContent>
+				</Select>
 				<Button onClick={handleAddGrader}>Add Grader</Button>
 			</div>
 		</div>


### PR DESCRIPTION
Fixes #19 

- Updated TrainingConfigPage to use a custom Select component for hyperparameters, core config, export config, and eval config.
- Refactored BatchInferenceForm to utilize the custom Select component for split selection.
- Enhanced RewardConfigurator by replacing select elements with the custom Select component for operation, evaluation metric, function name, and grader type selection.
- Improved UI consistency and user experience across forms.

<img width="937" height="306" alt="image" src="https://github.com/user-attachments/assets/928ce853-ed9b-4566-9c90-3fd3a8bca7f6" />
