### PR TITLE
fix: redirect to dataset selection when no dataset is selected

### DIFF
--- a/src/app/dashboard/datasets/configuration/page.tsx
+++ b/src/app/dashboard/datasets/configuration/page.tsx
@@ -184,6 +184,7 @@ const DatasetConfiguration = () => {
 	const handleProcessDataset = async () => {
 		if (!datasetSelection) {
 			toast.error("Please select a dataset first.");
+			router.replace("/dashboard/datasets/selection");
 			return;
 		}
 
@@ -502,7 +503,9 @@ const DatasetConfiguration = () => {
 	};
 
 	if (!datasetSelection) {
-		return <div>Please select a dataset first.</div>;
+		toast.error("Please select a dataset first.");
+		router.replace("/dashboard/datasets/selection");
+		return null;
 	}
 
 	return (


### PR DESCRIPTION
Fixes #20 

- Added a redirect to the dataset selection page if no dataset is selected, improving user experience by guiding users to make a selection.
- Updated error handling to display a toast notification when no dataset is selected.