### PR TITLE
[feat] Model comparison and Job details page

### DIFF
--- a/src/app/dashboard/utilities/export/[jobId]/page.tsx
+++ b/src/app/dashboard/utilities/export/[jobId]/page.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-// TODO: Checkout the new layout and try it out
-
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";

--- a/src/types/export.ts
+++ b/src/types/export.ts
@@ -32,7 +32,6 @@ export interface JobSchema {
 	job_id: string;
 	job_name: string;
 	user_id: string;
-	adapter_path: string;
 	base_model_id: string;
 	modality?: Modality;
 	artifacts?: JobArtifacts;

--- a/src/types/training.ts
+++ b/src/types/training.ts
@@ -1,3 +1,5 @@
+import type { JobArtifacts } from "./export";
+
 export interface EvaluationMetrics {
 	accuracy?: number;
 	perplexity?: number;
@@ -170,13 +172,21 @@ export interface TrainRequest {
 export interface TrainingJob {
 	job_id: string;
 	job_name?: string;
-	status?: "queued" | "preparing" | "training" | "completed" | "failed";
+	user_id?: string;
+	status?:
+		| "pending"
+		| "queued"
+		| "preparing"
+		| "training"
+		| "completed"
+		| "failed";
 	processed_dataset_id?: string;
+	dataset_id?: string;
 	base_model_id?: string;
 	created_at?: string;
+	updated_at?: string;
 	wandb_url?: string;
-	adapter_path?: string;
-	gguf_path?: string;
+	artifacts?: JobArtifacts;
 	error?: string;
 	modality?: "text" | "vision";
 	metrics?: EvaluationMetrics;


### PR DESCRIPTION
## Summary

- Updates schema for jobs, updates artefacts display, link to export page
- Reimplement two columns model comparison because that was removed accidentally.

## Note

for batch inferencing, the dataset is used on the "master" sheet on the left so both models are evaluated on the same dataset. for metrics, it is currently independent which is fine?? We will patch these all again when we introduce new benchmarks soon anyways